### PR TITLE
Use consts for supported key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An SSH key pair generator. Supports generating RSA and Ed25519 keys.
 ## Example
 
 ```go
-k, err := NewSSHKeyPair(".ssh", "my_awesome_key", []byte(""), "ed25519")
+k, err := NewSSHKeyPair(".ssh", "my_awesome_key", []byte(""), key.Ed25519)
 if err != nil {
 	fmt.Printf("error creating SSH key pair: %v", err)
 	os.Exit(1)

--- a/keygen.go
+++ b/keygen.go
@@ -20,6 +20,15 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// KeyType represents a type of SSH key.
+type KeyType string
+
+// Supported key types.
+const (
+	RSA     KeyType = "rsa"
+	Ed25519 KeyType = "ed25519"
+)
+
 const rsaDefaultBits = 4096
 
 // ErrMissingSSHKeys indicates we're missing some keys that we expected to
@@ -67,7 +76,7 @@ func (s SSHKeyPair) publicKeyPath() string {
 }
 
 // New generates an SSHKeyPair, which contains a pair of SSH keys.
-func New(path, name string, passphrase []byte, keyType string) (*SSHKeyPair, error) {
+func New(path, name string, passphrase []byte, keyType KeyType) (*SSHKeyPair, error) {
 	var err error
 	s := &SSHKeyPair{
 		KeyDir:   path,
@@ -87,9 +96,9 @@ func New(path, name string, passphrase []byte, keyType string) (*SSHKeyPair, err
 		return s, nil
 	}
 	switch keyType {
-	case "ed25519":
+	case Ed25519:
 		err = s.generateEd25519Keys()
-	case "rsa":
+	case RSA:
 		err = s.generateRSAKeys(rsaDefaultBits, passphrase)
 	default:
 		return nil, fmt.Errorf("unsupported key type %s", keyType)
@@ -101,7 +110,7 @@ func New(path, name string, passphrase []byte, keyType string) (*SSHKeyPair, err
 }
 
 // New generates an SSHKeyPair and writes it to disk if not exist.
-func NewWithWrite(path, name string, passphrase []byte, keyType string) (*SSHKeyPair, error) {
+func NewWithWrite(path, name string, passphrase []byte, keyType KeyType) (*SSHKeyPair, error) {
 	s, err := New(path, name, passphrase, keyType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a small PR to that introduces some types and constants for specifying SSH key types. This will help reduce errors as well as provide language servers with some completion options.