### PR TITLE
ref: change api to expose ssh.PublicKey and authorizd_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,29 +10,27 @@ An SSH key pair generator with password protected keys support. Supports generat
 ## Example
 
 ```go
-filepath := filepath.Join(".ssh",  "my_awesome_key")
-passphrase := []byte("awesome_secret")
-k, err := NewWithWrite(filepath, passphrase, key.Ed25519)
+kp, err := keygen.New("awesome", keygen.WithPassphrase("awesome_secret"),
+	keygen.WithKeyType(keygen.Ed25519))
 if err != nil {
-	fmt.Printf("error creating SSH key pair: %v", err)
-	os.Exit(1)
+	log.Fatalf("error creating SSH key pair: %v", err)
 }
-fmt.Printf("Your authorized key: %s\n", string(k.PublicKey()))
+fmt.Printf("Your authorized key: %s\n", kp.AuthorizedKey())
 ```
 
 ## Feedback
 
 We’d love to hear your thoughts on this project. Feel free to drop us a note!
 
-* [Twitter](https://twitter.com/charmcli)
-* [The Fediverse](https://mastodon.social/@charmcli)
-* [Discord](https://charm.sh/chat)
+- [Twitter](https://twitter.com/charmcli)
+- [The Fediverse](https://mastodon.social/@charmcli)
+- [Discord](https://charm.sh/chat)
 
 ## License
 
 [MIT](https://github.com/charmbracelet/keygen/raw/master/LICENSE)
 
-***
+---
 
 Part of [Charm](https://charm.sh).
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/caarlos0/sshmarshal v0.1.0
-	github.com/mitchellh/go-homedir v1.1.0
 	golang.org/x/crypto v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/caarlos0/sshmarshal v0.1.0 h1:zTCZrDORFfWh526Tsb7vCm3+Yg/SfW/Ub8aQDeosk0I=
 github.com/caarlos0/sshmarshal v0.1.0/go.mod h1:7Pd/0mmq9x/JCzKauogNjSQEhivBclCQHfr9dlpDIyA=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
### Breaking change!

Don't append keyType to path.
Use more concise method names.
Remove go-homedir dependency.
Use functional options.