### PR TITLE
fix: do not recreate key if public key don't exist

### DIFF
--- a/keygen.go
+++ b/keygen.go
@@ -480,7 +480,7 @@ func (s *SSHKeyPair) WriteKeys() error {
 
 // KeyPairExists checks if the SSH key pair exists on disk.
 func (s *SSHKeyPair) KeyPairExists() bool {
-	return fileExists(s.privateKeyPath()) && fileExists(s.publicKeyPath())
+	return fileExists(s.privateKeyPath())
 }
 
 func writeKeyToFile(keyBytes []byte, path string) error {


### PR DESCRIPTION
this would cause keygen to try to recreate the private key if the public key does not exist.

Since we can extract the public key from the private key, this seems too destructive IMO.


Maybe we should also try to re-write the public key if its missing?