### PR TITLE
fix: rename struct and deprecated the old name

### DIFF
--- a/keygen.go
+++ b/keygen.go
@@ -107,7 +107,7 @@ func (s KeyPair) publicKeyPath() string {
 	return s.privateKeyPath() + ".pub"
 }
 
-// Option is a functional option for SSHKeyPair.
+// Option is a functional option for KeyPair.
 type Option func(*KeyPair)
 
 // WithPassphrase sets the passphrase for the private key.

--- a/keygen.go
+++ b/keygen.go
@@ -150,7 +150,7 @@ func WithEllipticCurve(curve elliptic.Curve) Option {
 	}
 }
 
-// New generates an SSHKeyPair, which contains a pair of SSH keys.
+// New generates a KeyPair, which contains a pair of SSH keys.
 //
 // If the key pair already exists, it will be loaded from disk, otherwise, a
 // new SSH key pair is generated.
@@ -241,7 +241,7 @@ func (s *KeyPair) PrivateKey() crypto.PrivateKey {
 	}
 }
 
-// Ensure that SSHKeyPair implements crypto.Signer.
+// Ensure that KeyPair implements crypto.Signer.
 // This is used to ensure that the private key is a valid crypto.Signer to be
 // passed to ssh.NewSignerFromKey.
 var (
@@ -425,7 +425,7 @@ func (s *KeyPair) prepFilesystem() error {
 		info, err := os.Stat(keyDir)
 		if os.IsNotExist(err) {
 			// Directory doesn't exist: create it
-			return os.MkdirAll(keyDir, 0700)
+			return os.MkdirAll(keyDir, 0o700)
 		}
 		if err != nil {
 			// There was another error statting the directory; something is awry
@@ -435,9 +435,9 @@ func (s *KeyPair) prepFilesystem() error {
 			// It exists but it's not a directory
 			return FilesystemErr{Err: fmt.Errorf("%s is not a directory", keyDir)}
 		}
-		if info.Mode().Perm() != 0700 {
+		if info.Mode().Perm() != 0o700 {
 			// Permissions are wrong: fix 'em
-			if err := os.Chmod(keyDir, 0700); err != nil {
+			if err := os.Chmod(keyDir, 0o700); err != nil {
 				return FilesystemErr{Err: err}
 			}
 		}
@@ -489,7 +489,7 @@ func (s *KeyPair) KeyPairExists() bool {
 
 func writeKeyToFile(keyBytes []byte, path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return ioutil.WriteFile(path, keyBytes, 0600)
+		return ioutil.WriteFile(path, keyBytes, 0o600)
 	}
 	return FilesystemErr{Err: fmt.Errorf("file %s already exists", path)}
 }

--- a/keygen_test.go
+++ b/keygen_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestNewSSHKeyPair(t *testing.T) {
+func TestNewKeyPair(t *testing.T) {
 	kp, err := New("")
 	if err != nil {
 		t.Errorf("error creating SSH key pair: %v", err)
@@ -45,7 +45,7 @@ func nilTest(t testing.TB, kp *KeyPair) {
 	}
 }
 
-func TestNilSSHKeyPair(t *testing.T) {
+func TestNilKeyPair(t *testing.T) {
 	for _, kt := range []KeyType{RSA, Ed25519, ECDSA} {
 		t.Run(fmt.Sprintf("test nil key pair for %s", kt), func(t *testing.T) {
 			kp, err := New("", WithKeyType(kt))
@@ -57,7 +57,7 @@ func TestNilSSHKeyPair(t *testing.T) {
 	}
 }
 
-func TestNilSSHKeyPairWithPassphrase(t *testing.T) {
+func TestNilKeyPairWithPassphrase(t *testing.T) {
 	for _, kt := range []KeyType{RSA, Ed25519, ECDSA} {
 		t.Run(fmt.Sprintf("test nil key pair for %s", kt), func(t *testing.T) {
 			kp, err := New("", WithKeyType(kt), WithPassphrase("test"))
@@ -69,7 +69,7 @@ func TestNilSSHKeyPairWithPassphrase(t *testing.T) {
 	}
 }
 
-func TestNilSSHKeyPairTestdata(t *testing.T) {
+func TestNilKeyPairTestdata(t *testing.T) {
 	for _, kt := range []KeyType{RSA, Ed25519, ECDSA} {
 		t.Run(fmt.Sprintf("test nil key pair for %s", kt), func(t *testing.T) {
 			kp, err := New(filepath.Join("testdata", "test_"+kt.String()), WithPassphrase("test"), WithKeyType(kt))
@@ -228,7 +228,7 @@ func TestGenerateECDSAKeys(t *testing.T) {
 // touchTestFile is a utility function we're using in testing.
 func createEmptyFile(t *testing.T, path string) (ok bool) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Errorf("could not create directory %s: %v", dir, err)
 		return false
 	}

--- a/keygen_test.go
+++ b/keygen_test.go
@@ -20,7 +20,7 @@ func TestNewSSHKeyPair(t *testing.T) {
 	}
 }
 
-func nilTest(t testing.TB, kp *SSHKeyPair) {
+func nilTest(t testing.TB, kp *KeyPair) {
 	t.Helper()
 	if kp == nil {
 		t.Error("expected key pair to be non-nil")
@@ -97,7 +97,7 @@ func TestGenerateEd25519Keys(t *testing.T) {
 	dir := t.TempDir()
 	filename := "test"
 
-	k := &SSHKeyPair{
+	k := &KeyPair{
 		path:    filepath.Join(dir, filename),
 		keyType: Ed25519,
 	}
@@ -163,7 +163,7 @@ func TestGenerateECDSAKeys(t *testing.T) {
 	dir := t.TempDir()
 	filename := "test"
 
-	k := &SSHKeyPair{
+	k := &KeyPair{
 		path:    filepath.Join(dir, filename),
 		keyType: ECDSA,
 		ec:      elliptic.P384(),


### PR DESCRIPTION
`SSHKeyPair` is way too long and unnecessary