### PR TITLE
[cleanup]: remove ioutil package

### DIFF
--- a/keygen.go
+++ b/keygen.go
@@ -11,7 +11,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -175,7 +174,7 @@ func New(path string, opts ...Option) (*KeyPair, error) {
 	}
 
 	if s.KeyPairExists() {
-		privData, err := ioutil.ReadFile(s.privateKeyPath())
+		privData, err := os.ReadFile(s.privateKeyPath())
 		if err != nil {
 			return nil, err
 		}
@@ -488,7 +487,7 @@ func (s *KeyPair) KeyPairExists() bool {
 
 func writeKeyToFile(keyBytes []byte, path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return ioutil.WriteFile(path, keyBytes, 0o600)
+		return os.WriteFile(path, keyBytes, 0o600)
 	}
 	return FilesystemErr{Err: fmt.Errorf("file %s already exists", path)}
 }

--- a/keygen_test.go
+++ b/keygen_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/elliptic"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -260,7 +260,7 @@ func TestGeneratePublicKeyWithEmptyDir(t *testing.T) {
 				t.Fatalf("error opening SSH key file: %v", err)
 			}
 			defer f.Close()
-			fc, err := ioutil.ReadAll(f)
+			fc, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatalf("error reading SSH key file: %v", err)
 			}
@@ -289,7 +289,7 @@ func TestGenerateKeyWithPassphrase(t *testing.T) {
 				t.Fatalf("error opening SSH key file: %v", err)
 			}
 			defer f.Close()
-			fc, err := ioutil.ReadAll(f)
+			fc, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatalf("error reading SSH key file: %v", err)
 			}


### PR DESCRIPTION
## What is this ?

This commit removes ioutil package from keygen.go and keygen_test.go.

ioutil package is deprecated and same function is now provided by package io and package os
See more info ➡  https://pkg.go.dev/io/ioutil

## Checked

```shell
keygen [ remove-ioutil][🐹 v1.21.0]
❯ go test
PASS
ok  	github.com/charmbracelet/keygen	5.445s
```

