### PR TITLE
[refactor]: keygen: refactor same expression

### DIFF
--- a/keygen.go
+++ b/keygen.go
@@ -474,11 +474,8 @@ func (s *KeyPair) WriteKeys() error {
 	if memo := pubKeyMemo(); memo != "" {
 		ak = fmt.Sprintf("%s %s", ak, memo)
 	}
-	if err := writeKeyToFile([]byte(ak), s.publicKeyPath()); err != nil {
-		return err
-	}
 
-	return nil
+	return writeKeyToFile([]byte(ak), s.publicKeyPath())
 }
 
 // KeyPairExists checks if the SSH key pair exists on disk.


### PR DESCRIPTION
## What is this ?
This commit refactors same expression in keygen.go.
Removed unnecessary branches.

## Checked

```shell
keygen [ fix-same-expression][🐹 v1.21.0]
❯ go test
PASS
ok  	github.com/charmbracelet/keygen	8.394s
```