### PR TITLE
feat: allow to pass a custom fs

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,51 @@
+package keygen
+
+import (
+	"io/fs"
+	"os"
+)
+
+// KeyFS is an interface that defines everything we need to read and write
+// keys.
+type KeyFS interface {
+	fs.ReadFileFS
+	fs.StatFS
+	Chmod(name string, mode fs.FileMode) error
+	MkdirAll(path string, perm fs.FileMode) error
+	WriteFile(path string, data []byte, perm fs.FileMode) error
+}
+
+var _ KeyFS = &RealFS{}
+
+// RealFS is a KeyFS implementation that uses the real filesystem.
+type RealFS struct{}
+
+// WriteFile implements KeyFS.
+func (n *RealFS) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+// MkdirAll implements KeyFS.
+func (n *RealFS) MkdirAll(path string, perm fs.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// Chmod implements KeyFS.
+func (n *RealFS) Chmod(name string, mode fs.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
+// Open implements KeyFS.
+func (n *RealFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
+}
+
+// ReadFile implements KeyFS.
+func (n *RealFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+
+// Stat implements KeyFS.
+func (n *RealFS) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}

--- a/keygen_test.go
+++ b/keygen_test.go
@@ -100,6 +100,7 @@ func TestGenerateEd25519Keys(t *testing.T) {
 	k := &KeyPair{
 		path:    filepath.Join(dir, filename),
 		keyType: Ed25519,
+		fs:      &RealFS{},
 	}
 
 	t.Run("test generate SSH keys", func(t *testing.T) {
@@ -167,6 +168,7 @@ func TestGenerateECDSAKeys(t *testing.T) {
 		path:    filepath.Join(dir, filename),
 		keyType: ECDSA,
 		ec:      elliptic.P384(),
+		fs:      &RealFS{},
 	}
 
 	t.Run("test generate SSH keys", func(t *testing.T) {


### PR DESCRIPTION
Unfortunately we need more than the simple `fs.FS` interface, so I created an interface with everything we need.

This resulting interface is quite big, though, not sure if worth it.

Callers would have to implement this beefy interface to have it create keys in memory (doing nothing in some methods like chmod, mkdir, etc).

Maybe another approach could be to make another function public, having only the key type switch and returning private pem block and public key bytes?

refs #17